### PR TITLE
fix: membenarkan import pada file test ObjectTypes

### DIFF
--- a/TypeScriptBasic/03_ObjectTypes/Interface.test.ts
+++ b/TypeScriptBasic/03_ObjectTypes/Interface.test.ts
@@ -1,4 +1,4 @@
-import * as InterfaceFile from './interface';
+import * as InterfaceFile from './Interface';
 
 test('Mengecek fungsi PertambahanAdanB', () => {
   const dataInputParameter: InterfaceFile.ParameterFunctionPertambahanAdanB = {

--- a/TypeScriptBasic/03_ObjectTypes/type.test.ts
+++ b/TypeScriptBasic/03_ObjectTypes/type.test.ts
@@ -1,4 +1,4 @@
-import * as TypeFile from './type';
+import * as TypeFile from './Type';
 
 test('Mengetes fungsi ApakahTrue', () => {
   expect(TypeFile.ApakahTrue(true)).toBe('benar!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "bellshade-typescript",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,11 +2205,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@^2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
PR ini tidak berhubungan dengan issue apapun

## Deskripsi (Description)

Di PR ini, saya hanya ingin memperbaiki failing jest unit test pada ObjectTypes yang disebabkan oleh penggunaan case yang salah pada import.

- [ ] saya menambahkan algoritma terbaru
- [x] saya memperbaiki algoritma yang sudah ada
- [ ] saya memperbaiki dokumentasi
- [ ] saya menambah dokumentasi

## Contributor Requirements (Syarat Kontributor)

- [x] saya sudah membaca (i have read) [CONTRIBUTING](https://github.com/bellshade/Typescript/blob/main/CONTRIBUTING.md) dan sudah menyetujui semua
- [x] saya menggunakan bahasa indonesia untuk memberikan penjelasan dari kode yang saya buat

## Environment

saya menggunakan (im used):

- `os` = `windows`

## Testing

- [x] lint testing eslint

## Maintainer

**maintainer typescript**
@bellshade/typescript-team
